### PR TITLE
Create an EC2 hint for ohai, on linux/windows

### DIFF
--- a/lib/templates/chef/chef-install.ps1.erb
+++ b/lib/templates/chef/chef-install.ps1.erb
@@ -2,6 +2,7 @@ echo "Starting Chef installation..."
 
 $ChefVers       = "<%= (defined? chef_version) ? chef_version : '' %>"
 $ChefPath       = "C:\Chef"
+$OhaiHintsDir   = "$ChefPath\ohai\hints"
 $ChefLog        = "$ChefPath\log\bootscript_log.txt"
 $CreateRAMDisk  = $<%= create_ramdisk.to_s.upcase %>
 $RAMDiskMount   = "<%= ramdisk_mount %>"
@@ -11,6 +12,7 @@ function main()
   try
   {
     Create-Chef-Directory-Structure
+    Create-Ohai-Hints
     if ($createRAMDisk) { Move-Chef-Secrets-To-Ramdisk }
     Install-Chef-Client
     Execute-Chef-Client
@@ -21,15 +23,32 @@ function main()
   }
 }
 
+function Create-EC2-Hint()
+{
+  try {
+    $wc = New-Object System.Net.WebClient
+    $wc.DownloadString("http://169.254.169.254") | Out-Null
+    New-Item -Type file -Force -Path (Join-Path $OhaiHintsDir "ec2.json") | Out-Null
+  } catch {
+    # We are not an EC2 instance.
+  }
+}
+
+function Create-Ohai-Hints()
+{
+  try
+  {
+    Create-EC2-Hint
+  }
+  catch {throw $error[0]}
+}
+
 function Create-Chef-Directory-Structure()
 {
   try
   {
-    if (!(Test-Path $ChefPath)) {New-Item $ChefPath -type directory | out-null}
-    foreach($f in @("etc", "bin", "log", "tmp", "var"))
-    {
-      $subdir = "$($ChefPath)\$f"
-      if (!(Test-Path $subdir)) {New-Item $subdir -type directory | out-null}
+    @("etc", "bin", "log", "tmp", "var") | foreach {
+      New-Item -force -type directory -Path (Join-Path $ChefPath $_) | out-null
     }
   }
   catch {throw $error[0]}

--- a/lib/templates/chef/chef-install.sh.erb
+++ b/lib/templates/chef/chef-install.sh.erb
@@ -11,6 +11,7 @@ echo "Installing Chef with ${0}..."
 NODE_NAME="<%= chef_attributes['chef_client']['config']['node_name'] %>"
 CHEF_URL="<%= chef_attributes['chef_client']['config']['chef_server_url'] %>"
 VALIDATION_PEM='<%= ramdisk_mount %>/chef/validation.pem'
+OHAI_HINTS_DIR='<%= ramdisk_mount %>/chef/ohai/hints'
 DATABAG_SECRET='<%= ramdisk_mount %>/chef/encrypted_data_bag_secret'
 CHEF_VERSION="<%= (defined? chef_version) ? chef_version : '' %>"
 CHEF_INITIAL_RUNLIST="<%=
@@ -60,7 +61,15 @@ echo "Installing Chef..."
 $cmd
 rm -f $installer
 
-######### STEP 4: INITIAL, ONE-PASS CHEF CONVERGENCE
+######### STEP 4: SET UP ENVIRONMENT HINTS FOR OHAI
+echo "Establishing ohai hints directory: $OHAI_HINTS_DIR"
+mkdir -p "$OHAI_HINTS_DIR"
+if curl -m 60 -f -L -s -S -o /dev/null http://169.254.169.254; then
+  echo "Setting ohai hint: ec2"
+  touch "$OHAI_HINTS_DIR/ec2.json"
+fi
+
+######### STEP 5: INITIAL, ONE-PASS CHEF CONVERGENCE
 echo "Performing initial convergence..."
 cmd="$CHEF_BIN --once --no-color"
 if [[ "$CHEF_INITIAL_RUNLIST" != "" ]] ; then
@@ -69,7 +78,7 @@ fi
 echo $cmd
 $cmd
 
-######### STEP 5: SIGNAL SERVICE TO CONVERGE
+######### STEP 6: SIGNAL SERVICE TO CONVERGE
 echo "Signalling chef service to converge..."
 killall -USR1 chef-client || echo "  (...no chef client service detected)"
 


### PR DESCRIPTION
If the instance is an EC2 instance (discovered by accessing http://169.254.169.254), a hint file is created for ohai, telling it that the machine is an EC2 instance.

This allows chef to bootstrap and run when the instance is within a private VPC subnet.
