### PR TITLE
Update to enable the optional repo in rhel 7.x

### DIFF
--- a/lib/templates/bootscript.sh.erb
+++ b/lib/templates/bootscript.sh.erb
@@ -112,7 +112,7 @@ fi
 ####################################
 ####  STEP 5 - Check for uudecode, and attempt to install it if needed
 if ! (which uudecode >/dev/null 2>&1) ; then
-  flavor="$OS / $Dist / $DistroBasedOn"
+  flavor="$OS / $DIST / $DistroBasedOn"
   echo "uudecode not found - will attempt installation for $flavor"
   if [ "$OS" == 'linux' ] ; then
     if [ "$DistroBasedOn" == 'debian' ] ; then
@@ -121,6 +121,8 @@ if ! (which uudecode >/dev/null 2>&1) ; then
       yum -y update
       # As of RH6, the sharutils package is in the "optional" repo
       yum-config-manager --enable rhui-REGION-rhel-server-releases-optional
+      # As of RH7, the sharutils package is in the "optional" repo
+      yum-config-manager --enable rhui-REGION-rhel-server-optional
       yum -y install sharutils
     else
       echo "ERROR: Only Debian-derived and Red Hat Linux supported for now :("


### PR DESCRIPTION
There was an issue where an AMI running RHEL 7.3 was spun up but did not install chef client.  Examination showed that the sharutils package (required for uudecode) was not found in the repos enabled.  As this AMI used RHEL 7, the name of the repo to enable was different from RHEL 6 and required an update.

Fix a bug where the DIST var was not printed out.  