### PR TITLE
Update AWS autoscaling health checks on startup command failure

### DIFF
--- a/lib/templates/bootscript.sh.erb
+++ b/lib/templates/bootscript.sh.erb
@@ -151,9 +151,30 @@ echo "Executing user startup command..."
 <% if defined? chef_validation_pem %>
 chmod 0744 /usr/local/sbin/chef-install.sh
 <% end %>
-exec <%= startup_command %>
+if ! <%= startup_command %> ; then
+    echo "Startup command failed. This system may be unhealthy."
+
+    # The startup command failed so this instance is likely to be
+    # broken in some way. We should mark the instance as unhealthy
+    # if it's part of an AWS autoscaling group. This relies on the
+    # AWS CLI tools being installed.
+    if ec2_instance_id=$(curl -s http://169.254.169.254/latest/meta-data/instance-id) ; then
+        ec2_region=$(curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone | sed -e s'/.$//')
+        which aws >/dev/null && \
+            aws autoscaling describe-auto-scaling-instances \
+                --instance-ids $ec2_instance_id \
+                --region $ec2_region \
+                | grep -F $ec2_instance_id >/dev/null &&
+            aws autoscaling set-instance-health \
+                --instance-id $ec2_instance_id \
+                --health-status Unhealthy \
+                --no-should-respect-grace-period \
+                --region $ec2_region
+    fi
+    exit 1
+fi
 <% end %>
-exit 0  # This is reached only if there's no user startup command
+exit 0
 
 
 ####################################


### PR DESCRIPTION
This change uses the AWS CLI tools (if installed) on an EC2 instance (if it is an EC2 instance) to set the autoscaling health status (if the EC2 instance is part of an autoscaling group) to mark the instance as unhealthy if the startup command fails.

As part of this change, the startup command is now run in a subshell and the exit code is evaluated to determine success or failure.

I've tested this with real EC2 instances, both within ASGs and without, and with an AMI with the AWS CLI tools and without. I was even fortunate enough to have the Chef service restart fail when testing in an ASG, and the instance was replaced automatically.