### PR TITLE
Warn about an out-of-date aws-cli package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.rbc
 .bundle
 .config
+.idea
 .yardoc
 Gemfile.lock
 InstalledFiles

--- a/lib/templates/bootscript.sh.erb
+++ b/lib/templates/bootscript.sh.erb
@@ -158,19 +158,29 @@ if ! <%= startup_command %> ; then
     # broken in some way. We should mark the instance as unhealthy
     # if it's part of an AWS autoscaling group. This relies on the
     # AWS CLI tools being installed.
-    if ec2_instance_id=$(curl -s http://169.254.169.254/latest/meta-data/instance-id) ; then
-        ec2_region=$(curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone | sed -e s'/.$//')
-        which aws >/dev/null && \
-            aws autoscaling describe-auto-scaling-instances \
-                --instance-ids $ec2_instance_id \
-                --region $ec2_region \
-                | grep -F $ec2_instance_id >/dev/null &&
-            aws autoscaling set-instance-health \
-                --instance-id $ec2_instance_id \
-                --health-status Unhealthy \
-                --no-should-respect-grace-period \
-                --region $ec2_region
+
+    aws_cli_version=$(aws --version 2>&1 | awk '{print $1}' | awk -F/ '{print $2}')
+    aws_major=$(echo $aws_cli_version | awk -F. '{print $1}' | sed -e 's/[^0-9]//g')
+    aws_minor=$(echo $aws_cli_version | awk -F. '{print $2}' | sed -e 's/[^0-9]//g')
+    if [ "$aws_major" -le "1" -a "$aws_minor" -lt "11" ]; then
+        echo "The aws-cli package version is out of date; please upgrade your AMI."
+    else
+        if ec2_instance_id=$(curl -s http://169.254.169.254/latest/meta-data/instance-id) ; then
+            ec2_region=$(curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone | sed -e s'/.$//')
+            which aws >/dev/null && \
+                aws autoscaling describe-auto-scaling-instances \
+                    --instance-ids $ec2_instance_id \
+                    --region $ec2_region \
+                    | grep -F $ec2_instance_id >/dev/null &&
+                aws autoscaling set-instance-health \
+                    --instance-id $ec2_instance_id \
+                    --health-status Unhealthy \
+                    --no-should-respect-grace-period \
+                    --region $ec2_region
+        fi
+
     fi
+
     exit 1
 fi
 <% end %>


### PR DESCRIPTION
We are seeing this message at the bottom of bootscript.log, when older bakery AMIs are used:

> Invalid length for parameter InstanceIds[0], value: 19, valid range: 1-16

The reason is that the installed aws-cli package does not support the longer EC2 instance id. This change parses the version string for the package, and if believed to be prior to 1.11, emits a message suggesting an AMI upgrade.

I have tried to guard against not picking a number out of the version string.

@harryw @benton 