### PR TITLE
Use the Chef 'omnitruck' API to download Windows installer

### DIFF
--- a/lib/templates/chef/chef-install.ps1.erb
+++ b/lib/templates/chef/chef-install.ps1.erb
@@ -92,7 +92,7 @@ function Chef-Url()
   elseif ($winrev -eq "6.2") { $machineos = "2012" }
   elseif ($winrev -eq "6.3") { $machineos = "2012r2" }
   else   { throw "ERROR: Windows Server 2003, 2008 or 2012 required" }
-  $url = "https://www.opscode.com/chef/download?p=windows&pv=$machineos&m=$arch"
+  $url = "https://omnitruck.chef.io/stable/chef/download?p=windows&pv=$machineos&m=$arch"
   if ($ChefVers -ne "") { $url = "$url&v=$ChefVers" }
   return $url
 }


### PR DESCRIPTION
The www.opscode.com URI that we were using has started to intermittently return a 403 instead of a 3xx redirect to packages.chef.io, as expected. The omnitruck.chef.io URI is the recommended approach, so we'll use that instead.

I've done some brief testing and not run into the same error, but there are of course no guarantees that we won't encounter it again since it was intermittent.